### PR TITLE
Flutter Gradle 8 requirements

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -34,8 +34,9 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
-
+    compileSdk 34
+    namespace "com.adapty.adapty_ui_flutter"
+    
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.adapty.adapty_ui_flutter">
+    package="com.adapty.adapty_ui_flutter">
 </manifest>


### PR DESCRIPTION
- Change AGP to 8.1.3
- Deprecated compileSdkVersion change to compileSdk and set 34
- Add namespace for gradle 8 requirement